### PR TITLE
Fix compilation error on ARM and some Clippy warnings.

### DIFF
--- a/src/arithmetic/conversion.rs
+++ b/src/arithmetic/conversion.rs
@@ -85,7 +85,7 @@ pub(crate) fn to_hex_string(sign: Sign, digits: Vec<u64>) -> String{
                for i in digits.iter().rev(){
                  k = k.to_owned() + &format!("{:0X}",i);// &word_char(*i);
                }
-              return k
+              k
 }
 
 pub(crate) fn from_string(string: &str) -> Option<Vec<u64>> {

--- a/src/arithmetic/inlineops.rs
+++ b/src/arithmetic/inlineops.rs
@@ -89,8 +89,8 @@ pub(crate) fn sbb(carry: u8, x: u64, y: u64, output: &mut u64) -> u8 {
       }
         #[cfg(not(any(target_arch = "x86",target_arch="x86_64")))]
         {
-          let (flag,interim) = x.overflowing_sub(carry);
-          let (flag2,res) = interim.overflowing_sub(y);
+          let (interim,flag) = x.overflowing_sub(carry.into());
+          let (res,flag2) = interim.overflowing_sub(y);
           *output = res;
           if flag || flag2{
              return 1u8 

--- a/src/arithmetic/mpz.rs
+++ b/src/arithmetic/mpz.rs
@@ -88,7 +88,7 @@ impl Mpz {
 /// Return x from i128
     pub fn from_i128(x: i128) -> Self {
         if x < 0i128 {
-            let (x_lo, x_hi) = split(x.abs() as u128);
+            let (x_lo, x_hi) = split(x.unsigned_abs());
             if x_hi == 0 {
                 return Mpz::unchecked_new(Sign::Negative, vec![x_lo]);
             }
@@ -104,7 +104,7 @@ impl Mpz {
 /// Return x from i64
     pub fn from_i64(x: i64) -> Self {
         if x < 0i64 {
-            return Mpz::unchecked_new(Sign::Negative, vec![x.abs() as u64]);
+            return Mpz::unchecked_new(Sign::Negative, vec![x.unsigned_abs()]);
         }
         Mpz::unchecked_new(Sign::Positive, vec![x as u64])
     }
@@ -129,7 +129,7 @@ impl Mpz {
              if self.limbs[0] > i64::MAX as u64{
               return None
              }  
-             return Some((self.limbs[0] as i64)*flag)
+             Some((self.limbs[0] as i64)*flag)
             },
             _ => None,
         }
@@ -142,7 +142,7 @@ impl Mpz {
                    if self.limbs[0] > u32::MAX as u64 {
                       return None
                    } 
-                   return Some(self.limbs[0] as u32);
+                   Some(self.limbs[0] as u32)
                  }
             _ => None,
         }
@@ -169,7 +169,7 @@ impl Mpz {
       }
       let mut interim = (0..k).map(|_| u64::rng()).collect::<Vec<u64>>();
       
-      interim[k-1] =  interim[k-1]&((1<<(len%64))-1);
+      interim[k-1] &= (1<<(len%64))-1;
       let mut result = Mpz::unchecked_new(Sign::Positive, interim);
       result.set_bit(len-1);
       result
@@ -300,7 +300,7 @@ impl Mpz {
        if self.len() == 1 && self.limbs[0] == 1{
          return true
        }
-       return false
+       false
     }
     /// Checks if n >= 0
     pub fn is_positive(&self) -> bool {
@@ -323,7 +323,7 @@ impl Mpz {
                 return false;
             }
         }
-        return true;
+        true
     }
 
     pub(crate) fn is_fermat(&self) -> bool {
@@ -714,7 +714,7 @@ impl Mpz {
     
     let (gcd, bezout_1, bezout_2) = self.extended_gcd(other);
     
-    return (gcd, bezout_1.residue(other), bezout_2.residue(self))
+    (gcd, bezout_1.residue(other), bezout_2.residue(self))
      
     }
 

--- a/src/arithmetic/mpz_ent.rs
+++ b/src/arithmetic/mpz_ent.rs
@@ -20,11 +20,11 @@ impl NumberTheory for Mpz {
       if ring.clone() == Mpz::zero(){
         return self.clone()
       } 
-      let rem = self.ref_euclidean(&ring).1;
+      let rem = self.ref_euclidean(ring).1;
       if !self.is_positive(){
         return self.ref_subtraction(&rem)
       }
-      return rem
+      rem
     }
 
     fn euclidean_div(&self, other: &Self) -> (Self, Self) {
@@ -401,7 +401,7 @@ impl NumberTheory for Mpz {
 
     fn prime_gen(x: u32) -> NTResult<Mpz> {
         if x < 128 {
-         return u128::prime_gen(x).map(|y| Mpz::from_u128(y))  
+         return u128::prime_gen(x).map(Mpz::from_u128)  
         }
         
         let mut form = Mpz::one().shl(x as usize-1);
@@ -470,7 +470,7 @@ impl NumberTheory for Mpz {
         }
         
         let cf = self.gcd(other);
-        self.euclidean_div(&cf).0.ref_product(&other)
+        self.euclidean_div(&cf).0.ref_product(other)
     }
 
     fn checked_lcm(&self, other: &Self) -> NTResult<Self> {
@@ -647,13 +647,13 @@ impl NumberTheory for Mpz {
     
     fn radical(&self) -> NTResult<Self>{
        match self.to_u64(){
-        Some(x) => return x.radical().map(|y| Mpz::from_u64(y)),
+        Some(x) => x.radical().map(Mpz::from_u64),
         None => {
           let mut rad = Mpz::one();
            for i in self.factor().iter().step_by(2) {
               rad = rad.ref_product(i)
            }
-          return NTResult::Eval(rad)
+          NTResult::Eval(rad)
          },
        }
     }
@@ -718,7 +718,7 @@ impl NumberTheory for Mpz {
     fn carmichael_totient(&self) -> NTResult<Self>{
        
        match self.to_u128(){
-         Some(x)=> return x.carmichael_totient().map(|y| Mpz::from_u128(y)),
+         Some(x)=> return x.carmichael_totient().map(Mpz::from_u128),
          None => (),
        }
        
@@ -791,7 +791,7 @@ impl NumberTheory for Mpz {
         if primeomega.is_even() {
             return 1;
         }
-        return -1;
+        -1
     }
     
     fn derivative(&self) -> NTResult<Self> {
@@ -819,7 +819,7 @@ impl NumberTheory for Mpz {
         if fctr.len() != 2 {
             return 0f64;
         }
-        return fctr[0].ln();
+        fctr[0].ln()
     }
     
     
@@ -841,7 +841,7 @@ impl NumberTheory for Mpz {
       if fctrsum&1 == 1{// if odd number of factors and square free
         return -1
       }
-      return 1
+      1
     }
 
     fn jacobi(&self, k: &Self) -> i8 {
@@ -919,7 +919,7 @@ impl NumberTheory for Mpz {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1].to_u64().unwrap() as u32);
    }
-   return res*multiplier
+   res*multiplier
 }
     
     fn smooth(&self) -> NTResult<Self> {
@@ -941,7 +941,7 @@ impl NumberTheory for Mpz {
       NTResult::Eval(x) => {
       let mut k = b.clone();
         k.set_sign(Sign::Positive);
-        return matches!(x.u_cmp(&k), Ordering::Less)
+        matches!(x.u_cmp(&k), Ordering::Less)
       }, 
       _=> false,
      }

--- a/src/arithmetic/mpz_prime.rs
+++ b/src/arithmetic/mpz_prime.rs
@@ -178,7 +178,7 @@ impl Mpz {
         }
 
         // insert a sieve that optimizes to eliminate composites (this does not appear to be any more efficient than using the hardcoded primes )
-        return true;
+        true
     }
     
    pub(crate) fn _trial_list(&self, primes: &[u64]) -> bool{
@@ -187,7 +187,7 @@ impl Mpz {
          return false
         }
       }
-      return true
+      true
     }
 
     // weighted strong fermat bases starting from 2^128
@@ -267,10 +267,8 @@ pub fn psp(k: usize) -> NTResult<Self>{
  loop {
   let len = (k-corrector)/2;
   let mut x = Mpz::rand(len);
-  if corrector == 3{
-   if !x.check_bit(len-2){
+  if corrector == 3 && !x.check_bit(len-2){
     x.flip_bit(len-2);
-   }
   }
   if corrector == 1{
     if x.check_bit(len-2){
@@ -316,7 +314,7 @@ pub fn miller(&self) -> bool{
        }
      }
    }
-   return true
+   true
 }
     
   
@@ -354,5 +352,5 @@ pub(crate) fn detect_pseudo_mpz(x: &Mpz) -> bool {
             return true;
         }
     }
-    return false;
+    false
 }

--- a/src/arithmetic/sign.rs
+++ b/src/arithmetic/sign.rs
@@ -1,17 +1,12 @@
 
 /// Enum representing the sign
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Default)]
 pub enum Sign {
    /// N >= 0 representation
+    #[default]
     Positive,
    /// N <  0 representation 
     Negative,
-}
-
-impl Default for Sign {
-    fn default() -> Self {
-        Sign::Positive
-    }
 }
 
 impl Sign {

--- a/src/primitive/byte.rs
+++ b/src/primitive/byte.rs
@@ -82,13 +82,13 @@ impl NumberTheory for u8 {
             let mut witness = Self::rng() % (self - 2) + 2;
 
             'witness: loop {
-                if witness.gcd(&self) == 1 {
+                if witness.gcd(self) == 1 {
                     break 'witness;
                 }
                 witness += 1;
             }
 
-            if witness.exp_residue(&x_minus, &self) != 1 {
+            if witness.exp_residue(&x_minus, self) != 1 {
                 // If any witness says it's composite then it is
                 certificate[0] = witness;
 
@@ -112,9 +112,7 @@ impl NumberTheory for u8 {
         let inf = std::cmp::min(*self, *sup);
         let mut hi = std::cmp::max(*self, *sup);
 
-        if hi < u8::MAX {
-            hi += 1;
-        }
+        hi = hi.saturating_add(1);
 
         let mut primevector = vec![];
 
@@ -253,7 +251,7 @@ impl NumberTheory for u8 {
            return(base,p)
          }
       }
-     return (*self,1)
+     (*self,1)
     }    
 
     
@@ -386,7 +384,7 @@ impl NumberTheory for u8 {
         for i in self.factor().iter().step_by(2) {
             let pow = i.pow(*k as u32);
 
-            denom = denom * pow;
+            denom *= pow;
 
             numer *= pow - 1;
         }
@@ -530,7 +528,7 @@ impl NumberTheory for u8 {
         if (LIOUVILLE_LUT[(*self / 64) as usize] >> (*self % 64)) & 1 == 1 {
             return -1;
         }
-        return 1;
+        1
     }
     
     fn mobius(&self) -> i8 {
@@ -553,7 +551,7 @@ impl NumberTheory for u8 {
       if fctrsum&1 == 1{// if odd number of factors and square free
         return -1
       }
-      return 1
+      1
     }
 
     fn mangoldt(&self) -> f64 {
@@ -561,7 +559,7 @@ impl NumberTheory for u8 {
        if base.is_prime(){
          return (base as f64).ln()
        }
-        return 0f64
+       0f64
     }
 
     fn jacobi(&self, k: &Self) -> i8 {
@@ -593,7 +591,7 @@ impl NumberTheory for u8 {
     }
     
     fn kronecker(&self, k: &Self) -> i8{
-     let x = self.clone();
+     let x = *self;
      if *k == 0{
       if x == 1{
          return 1
@@ -625,7 +623,7 @@ impl NumberTheory for u8 {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1] as u32);
    }
-   return res
+   res
 }
 
     fn checked_jacobi(&self, k: &Self) -> NTResult<i8> {

--- a/src/primitive/eightbytes.rs
+++ b/src/primitive/eightbytes.rs
@@ -59,13 +59,13 @@ impl NumberTheory for u64 {
             let mut witness = Self::rng() % (self - 2) + 2;
 
             'witness: loop {
-                if witness.gcd(&self) == 1 {
+                if witness.gcd(self) == 1 {
                     break 'witness;
                 }
                 witness += 1;
             }
 
-            if witness.exp_residue(&x_minus, &self) != 1 {
+            if witness.exp_residue(&x_minus, self) != 1 {
                 // If any witness says it's composite then it is
                 certificate[0] = witness;
 
@@ -89,9 +89,7 @@ impl NumberTheory for u64 {
         let inf = std::cmp::min(*self, *sup);
         let mut hi = std::cmp::max(*self, *sup);
 
-        if hi < u64::MAX {
-            hi += 1;
-        }
+        hi = hi.saturating_add(1);
 
         let mut primevector = vec![];
 
@@ -277,7 +275,7 @@ impl NumberTheory for u64 {
            return(base,p)
          }
       }
-     return (*self,1)
+     (*self,1)
     }    
     
     fn radical(&self) -> NTResult<Self> {
@@ -414,7 +412,7 @@ impl NumberTheory for u64 {
         for i in self.factor().iter().step_by(2) {
             let pow = i.pow(*k as u32);
 
-            denom = denom * pow;
+            denom *= pow;
 
             numer *= pow - 1;
         }
@@ -533,7 +531,7 @@ impl NumberTheory for u64 {
         if primeomega & 1 == 0 {
             return 1;
         }
-        return -1;
+        -1
     }
     
     fn derivative(&self) -> NTResult<Self> {
@@ -560,7 +558,7 @@ impl NumberTheory for u64 {
        if base.is_prime(){
          return (base as f64).ln()
        }
-        return 0f64
+       0f64
     }
     
     fn mobius(&self) -> i8 {
@@ -580,7 +578,7 @@ impl NumberTheory for u64 {
       if fctrsum&1 == 1{// if odd number of factors and square free
         return -1
       }
-      return 1
+      1
     }
 
     fn jacobi(&self, k: &Self) -> i8 {
@@ -619,7 +617,7 @@ impl NumberTheory for u64 {
     }
     
      fn kronecker(&self, k: &Self) -> i8{
-     let x = self.clone();
+     let x = *self;
      if *k == 0{
       if x == 1{
          return 1
@@ -651,7 +649,7 @@ impl NumberTheory for u64 {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1] as u32);
    }
-   return res
+   res
 }
 
 

--- a/src/primitive/fourbytes.rs
+++ b/src/primitive/fourbytes.rs
@@ -72,13 +72,13 @@ impl NumberTheory for u32 {
             let mut witness = Self::rng() % (self - 2) + 2;
 
             'witness: loop {
-                if witness.gcd(&self) == 1 {
+                if witness.gcd(self) == 1 {
                     break 'witness;
                 }
                 witness += 1;
             }
 
-            if witness.exp_residue(&x_minus, &self) != 1 {
+            if witness.exp_residue(&x_minus, self) != 1 {
                 // If any witness says it's composite then it is
                 certificate[0] = witness;
 
@@ -254,7 +254,7 @@ impl NumberTheory for u32 {
            return(base,p)
          }
       }
-     return (*self,1)
+     (*self,1)
     }    
     
     fn radical(&self) -> NTResult<Self> {
@@ -522,7 +522,7 @@ impl NumberTheory for u32 {
         if primeomega & 1 == 0 {
             return 1;
         }
-        return -1;
+        -1
     }
     
     fn derivative(&self) -> NTResult<Self> {
@@ -550,7 +550,7 @@ impl NumberTheory for u32 {
        if base.is_prime(){
          return (base as f64).ln()
        }
-        return 0f64
+        0f64
     }
     
     fn mobius(&self) -> i8 {
@@ -570,7 +570,7 @@ impl NumberTheory for u32 {
       if fctrsum&1 == 1{// if odd number of factors and square free
         return -1
       }
-      return 1
+      1
     }
 
     fn jacobi(&self, k: &Self) -> i8 {
@@ -609,7 +609,7 @@ impl NumberTheory for u32 {
     }
     
   fn kronecker(&self, k: &Self) -> i8{
-     let x = self.clone();
+     let x = *self;
      if *k == 0{
       if x == 1{
          return 1
@@ -641,7 +641,7 @@ impl NumberTheory for u32 {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1]);
    }
-   return res
+   res
 }
 
  fn smooth(&self) -> NTResult<Self> {

--- a/src/primitive/signednt.rs
+++ b/src/primitive/signednt.rs
@@ -50,9 +50,7 @@ impl NumberTheory for $t{
         let inf = std::cmp::min(*self, *sup);
         let mut hi = std::cmp::max(*self,*sup);
 
-        if hi < Self::MAX{
-           hi+=1;
-        }
+        hi = hi.saturating_add(1);
 
         let mut primevector = vec![];
 

--- a/src/primitive/sixteenbytes.rs
+++ b/src/primitive/sixteenbytes.rs
@@ -134,13 +134,13 @@ impl NumberTheory for u128 {
             let mut witness = Self::rng() % (self - 2) + 2;
 
             'witness: loop {
-                if witness.gcd(&self) == 1 {
+                if witness.gcd(self) == 1 {
                     break 'witness;
                 }
                 witness += 1;
             }
 
-            if witness.exp_residue(&x_minus, &self) != 1 {
+            if witness.exp_residue(&x_minus, self) != 1 {
                 // If any witness says it's composite then it is
                 certificate[0] = witness;
 
@@ -164,9 +164,7 @@ impl NumberTheory for u128 {
         let inf = std::cmp::min(*self, *sup);
         let mut hi = std::cmp::max(*self, *sup);
 
-        if hi < u128::MAX {
-            hi += 1;
-        }
+        hi = hi.saturating_add(1);
 
         let mut primevector = vec![];
 
@@ -344,7 +342,7 @@ impl NumberTheory for u128 {
            return(base,p)
          }
       }
-     return (*self,1)
+     (*self,1)
     }    
 
     fn radical(&self) -> NTResult<Self> {
@@ -507,7 +505,7 @@ impl NumberTheory for u128 {
         for i in self.factor().iter().step_by(2) {
             let pow = i.pow(*k as u32);
 
-            denom = denom * pow;
+            denom *= pow;
 
             numer *= pow - 1;
         }
@@ -622,7 +620,7 @@ impl NumberTheory for u128 {
         if primeomega & 1 == 0 {
             return 1;
         }
-        return -1;
+        -1
     }
     
     fn derivative(&self) -> NTResult<Self> {
@@ -649,7 +647,7 @@ impl NumberTheory for u128 {
        if base.is_prime(){
          return (base as f64).ln()
        }
-        return 0f64
+        0f64
     }
     
     fn mobius(&self) -> i8 {
@@ -708,7 +706,7 @@ impl NumberTheory for u128 {
     }
     
      fn kronecker(&self, k: &Self) -> i8{
-     let x = self.clone();
+     let x = *self;
      if *k == 0{
       if x == 1{
          return 1
@@ -740,7 +738,7 @@ impl NumberTheory for u128 {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1] as u32);
    }
-   return res
+   res
 }
 
 fn smooth(&self) -> NTResult<Self> {
@@ -922,7 +920,7 @@ fn detect_pseudo_128(x: u128) -> bool {
             return true;
         }
     }
-    return false;
+    false
 }
 
 fn jacobi_check_128(x: u128) -> bool {

--- a/src/primitive/twobytes.rs
+++ b/src/primitive/twobytes.rs
@@ -109,9 +109,7 @@ impl NumberTheory for u16 {
         let inf = std::cmp::min(*self, *sup);
         let mut hi = std::cmp::max(*self, *sup);
 
-        if hi < u16::MAX {
-            hi += 1;
-        }
+        hi = hi.saturating_add(1);
 
         let mut primevector = vec![];
 
@@ -269,7 +267,7 @@ impl NumberTheory for u16 {
            return(base,p)
          }
       }
-     return (*self,1)
+     (*self,1)
     }    
     
     fn radical(&self) -> NTResult<Self> {
@@ -558,7 +556,7 @@ impl NumberTheory for u16 {
         if (LIOUVILLE_LUT[(*self / 64) as usize] >> (*self % 64)) & 1 == 1 {
             return -1;
         }
-        return 1;
+        1
     }
     
     fn derivative(&self) -> NTResult<Self> {
@@ -585,7 +583,7 @@ impl NumberTheory for u16 {
        if base.is_prime(){
          return (base as f64).ln()
        }
-        return 0f64
+        0f64
     }
     
     fn mobius(&self) -> i8 {
@@ -605,7 +603,7 @@ impl NumberTheory for u16 {
       if fctrsum&1 == 1{// if odd number of factors and square free
         return -1
       }
-      return 1
+      1
     }
 
     fn jacobi(&self, k: &Self) -> i8 {
@@ -644,7 +642,7 @@ impl NumberTheory for u16 {
     }
     
      fn kronecker(&self, k: &Self) -> i8{
-     let x = self.clone();
+     let x = *self;
      if *k == 0{
       if x == 1{
          return 1
@@ -676,7 +674,7 @@ impl NumberTheory for u16 {
    for i in start..fctr.len()/2{
      res*=self.legendre(&fctr[2*i]).pow(fctr[2*i+1] as u32);
    }
-   return res
+   res
 }
 
     fn smooth(&self) -> NTResult<Self> {

--- a/src/sieve.rs
+++ b/src/sieve.rs
@@ -44,7 +44,6 @@ pub(crate) fn prime_list_32(inf: usize, sup: usize, data: &[u32]) -> Vec<u32> {
     let ndxlmt = (sup - 3) / 2 + 1;
     let lo: isize = (inf as isize - 3) / 2 + 1; // lo = -1;
     let temp = (lo..ndxlmt as isize)
-        .into_iter()
         .filter_map(move |i| {
             if i < 0 {
                 Some(2)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -369,7 +369,7 @@ impl Reduction for Mpz{
     if self.len() < 3{
       return true
     }
-    return false
+    false
   }
 }
 


### PR DESCRIPTION
Fixing the following compilation errors:
```
error[E0308]: mismatched types
  --> /home/xazax/.cargo/registry/src/index.crates.io-6f17d22bba15001f/number-theory-0.0.24/src/arithmetic/inlineops.rs:92:50
   |
92 |           let (flag,interim) = x.overflowing_sub(carry);
   |                                  --------------- ^^^^^ expected `u64`, found `u8`
   |                                  |
   |                                  arguments to this method are incorrect
   |
note: method defined here
  --> /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/num/mod.rs:1167:5
   = note: this error originates in the macro `uint_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
help: you can convert a `u8` to a `u64`
   |
92 |           let (flag,interim) = x.overflowing_sub(carry.into());
   |                                                       +++++++

error[E0599]: no method named `overflowing_sub` found for type `bool` in the current scope
  --> /home/xazax/.cargo/registry/src/index.crates.io-6f17d22bba15001f/number-theory-0.0.24/src/arithmetic/inlineops.rs:93:37
   |
93 |           let (flag2,res) = interim.overflowing_sub(y);
   |                                     ^^^^^^^^^^^^^^^ method not found in `bool`

error[E0308]: mismatched types
  --> /home/xazax/.cargo/registry/src/index.crates.io-6f17d22bba15001f/number-theory-0.0.24/src/arithmetic/inlineops.rs:95:14
   |
95 |           if flag || flag2{
   |              ^^^^ expected `bool`, found `u64`
```